### PR TITLE
Potential fix for code scanning alert no. 8: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,4 +1,6 @@
 name: Deploy to Cloud Run
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/francoisosmozis-hue/Hippique-Analyse-0925/security/code-scanning/8](https://github.com/francoisosmozis-hue/Hippique-Analyse-0925/security/code-scanning/8)

To fix the problem, the `permissions` key should be added to the workflow YAML file to restrict the permissions of the `GITHUB_TOKEN` to the minimal set needed—usually `contents: read` for workflows that only check out code and do not require write access to git or the repo. This should be placed at the top level of the YAML, just after the `name` and before or after the `on:` key. No imports or additional configuration are required; this is wholly a YAML configuration fix.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
